### PR TITLE
src/expand.c: avoid assignment of incompatibple pointers

### DIFF
--- a/src/expand.c
+++ b/src/expand.c
@@ -710,7 +710,9 @@ static char *   replace(
         } else {
             m_inf->locs.start_col = m_inf->locs.start_line = 0L;
         }
-        m_inf->args = m_inf->loc_args = NULL;       /* Default args */
+        /* Default args */
+        m_inf->args = NULL;
+        m_inf->loc_args = NULL;
         for (num = 1, recurs = 0; num < m_num; num++)
             if (mac_inf[ num].defp == defp)
                 recurs++;           /* Recursively nested macro     */


### PR DESCRIPTION
Upcoming `gcc-14` added and enabled as an error by default the check for assignment of incompatible pointers. There `mcpp` build fails as:

    expand.c: In function 'replace':
    expand.c:713:21: error: assignment to 'char *' from incompatible pointer type 'LOCATION *' {aka 'struct location *'} [-Wincompatible-pointer-types]
      713 |         m_inf->args = m_inf->loc_args = NULL;       /* Default args */
          |                     ^

The mismatch happens because `args` and `loc_args` have incompatible types:

    char *          args;
    LOCATION *      loc_args;

The change splits pointer assignments in two.