### PR TITLE
Fix segfault from freeing non-heap in_file pointer

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -384,7 +384,7 @@ int     main
 #endif
         }
     } else {
-        in_file = stdin_name;
+        in_file = strcpy( xmalloc( strlen( stdin_name) + 1), stdin_name);
     }
     /* Open output file, "-" means stdout.  */
     if (out_file != NULL && ! str_eq( out_file, "-")) {

--- a/src/system.c
+++ b/src/system.c
@@ -2167,7 +2167,7 @@ static char *   set_files(
 #if SYS_FAMILY == SYS_WIN
         cp = bsl2sl( cp);
 #endif
-        *in_pp = cp;
+        *in_pp = strcpy( xmalloc( strlen( cp) + 1), cp);
     }
     if (mcpp_optind < argc && argv[ mcpp_optind][ 0] != '-'
             && *out_pp == NULL) {


### PR DESCRIPTION
The cleanup code in main.c always freed in_file, but it wasn't always heap-allocated. When norm_path() returned NULL (file doesn't exist or isn't a regular file), in_file still pointed to argv or a string literal. This caused a segfault when free() was called during cleanup.

Fix by duplicating in_file to heap memory in all cases where it would otherwise point to non-heap memory (argv or string literals). Though slightly inefficient, this approach reliably avoids the segfault without introducing memory leaks or requiring additional logic to track whether in_file is heap-allocated.

Since strdup is not available, I used an existing pattern I saw e.g. in `support.c:2310` / `system.c:3628` to copy the string.